### PR TITLE
Make exclusion more verbose

### DIFF
--- a/lib/exclude_packages.js
+++ b/lib/exclude_packages.js
@@ -1,9 +1,23 @@
 module.exports = (reporters, excludedPackages) => {
-  return reporters.filter((p) => {
+  var removedPackages = false;
+
+  console.log(`Exclusion list:  ${excludedPackages.map((pkg) => pkg.name).join(", ")}`);
+  console.log(`Existing reporter list:  ${reporters.join(", ")} )`);
+
+  const result = reporters.filter((p) => {
     if (excludedPackages.find((pkg) => pkg.name === p)) {
+      removedPackages = true;
       console.log(`Removing ${p} from reporter list`);
       return false;
     }
     return true;
   });
+
+  if (removedPackages) {
+    console.log(`Resulting reporter list:  ${result.join(", ")} )`);
+  } else {
+    console.log("No reporters were removed. Resulting reporter list is unchanged");
+  }
+
+  return result;
 };


### PR DESCRIPTION
No change in functionality except module exclusion is more verbose and shows the state of `reporters` before and after exclusion.